### PR TITLE
Added itemClassificationScheme codelist

### DIFF
--- a/codelists/+itemClassificationScheme.csv
+++ b/codelists/+itemClassificationScheme.csv
@@ -1,0 +1,3 @@
+
+Code,Title,Description,Source,Context
+TED_CATEGORY,Areas covered by the public transport services,,https://simap.ted.europa.eu/documents/10184/49059/t02_en.pdf,tender

--- a/extension.json
+++ b/extension.json
@@ -14,6 +14,9 @@
   "schemas": [
     "release-schema.json"
   ],
+  "codelists": [
+    "+itemClassificationScheme.csv"
+  ],
   "contactPoint": {
     "name": "Open Contracting Partnership",
     "email": "data@open-contracting.org"


### PR DESCRIPTION
This one is a bit weird, this codelist has a single code, at least in the scope of forms (01, Rail transport services).

Again, unless I copy the the Title, I didn't know what to add in Description.